### PR TITLE
fix: config to ignore unknow properties

### DIFF
--- a/example/request_transmitted_docs.py
+++ b/example/request_transmitted_docs.py
@@ -28,7 +28,6 @@ def main():
 
     try:
         response_doc = client.request_transmitted_docs()
-        print(response_doc)
 
     except MyDataException as http_err:
         print("HTTP error occurred:", http_err)

--- a/mydata/utils/xml_parser.py
+++ b/mydata/utils/xml_parser.py
@@ -3,6 +3,7 @@ from typing import Any, Type
 
 from xsdata.formats.dataclass.context import XmlContext
 from xsdata.formats.dataclass.parsers import XmlParser
+from xsdata.formats.dataclass.parsers.config import ParserConfig
 
 
 class XMLResponseParser:
@@ -14,7 +15,8 @@ class XMLResponseParser:
     }
 
     def __init__(self):
-        self.parser = XmlParser(context=XmlContext())
+        config = ParserConfig(fail_on_unknown_properties=False)
+        self.parser = XmlParser(context=XmlContext(), config=config)
 
     def parse(self, xml_data: str, model: Type[Any]) -> Any:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mydatanaut"
-version = "0.1.3"
+version = "0.1.4"
 description = "Python library for AADE myData REST API"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Added a config flag to `XMLParser` in order to avoid hard-failures when bumping on unknown properties